### PR TITLE
Add set by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dot-path-value
 
-Safely get deep nested properties using dot notation.
+Safely get and set deep nested properties using dot notation.
 
 <a href="https://www.npmjs.com/package/dot-path-value">
   <img alt="npm version" src="https://img.shields.io/npm/v/dot-path-value.svg?style=flat-square" />
@@ -40,7 +40,7 @@ yarn add dot-path-value
 ## Usage
 
 ```ts
-import { getByPath } from 'dot-path-value';
+import { getByPath, setByPath } from 'dot-path-value';
 
 const obj = {
   a: {
@@ -65,6 +65,10 @@ getByPath([{ a: 1 }], '0.a'); // outputs '1' with type `number`
 
 // typescript errors
 getByPath(obj, 'a.b.c'); // `c` property does not exist
+
+
+// set a property through an object
+setByPath(obj, 'a.b', "hello there");
 ```
 
 ## Types

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,6 @@
-import { getByPath } from './index';
+import { getByPath, setByPath } from './index';
+
+let obj: { a: { b: { c: number } }; d: { e: number }[] };
 
 describe('getByPath', () => {
   const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
@@ -16,7 +18,7 @@ describe('getByPath', () => {
   });
 
   test('should work with optional keys', () => {
-    interface ObjType  {
+    interface ObjType {
       a?: {
         b: {
           c: string;
@@ -25,5 +27,45 @@ describe('getByPath', () => {
     }
     const obj: ObjType = {};
     expect(getByPath(obj, 'a.b.c')).toBe(undefined);
+  });
+});
+
+describe('setByPath', () => {
+  beforeEach(() => {
+    obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+  });
+
+  test("should set the value at the specified path", () => {
+    setByPath(obj, "a.b.c", 2);
+    expect(obj.a.b.c).toEqual(2);
+
+    setByPath(obj, "d.0.e", 4);
+    expect(obj.d[0]?.e).toEqual(4);
+
+    setByPath(obj, "d", []);
+    expect(obj.d).toEqual([]);
+  });
+
+  test('should work with arrays', () => {
+    const arr = [1, 2, { a: 3 }];
+    setByPath(arr, "0", 5);
+    expect(arr[0]).toBe(5);
+
+    setByPath(arr, '2.a', 6)
+    expect(getByPath(arr, '2.a')).toBe(6);
+
+  });
+
+  test('should set nothing if the parent path does not exist', () => {
+    interface ObjType {
+      a?: {
+        b: {
+          c: string;
+        };
+      };
+    }
+    const obj: ObjType = {};
+    setByPath(obj, 'a.b.c', 'test');
+    expect(obj).toEqual({});
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,5 @@
 import { getByPath, setByPath } from './index';
 
-let obj: { a: { b: { c: number } }; d: { e: number }[] };
-
 describe('getByPath', () => {
   const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
 
@@ -31,11 +29,9 @@ describe('getByPath', () => {
 });
 
 describe('setByPath', () => {
-  beforeEach(() => {
-    obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
-  });
-
   test("should set the value at the specified path", () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+
     setByPath(obj, "a.b.c", 2);
     expect(obj.a.b.c).toEqual(2);
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import { getByPath, setByPath } from './index';
 
+
 describe('getByPath', () => {
   const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
 
@@ -52,7 +53,13 @@ describe('setByPath', () => {
 
   });
 
-  test('should set nothing if the parent path does not exist', () => {
+  test('should return the changed object', () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+    const result = setByPath(obj, "a.b.c", 2);
+    expect(result).toBe(obj);
+  });
+
+  test('should a value in paths containing optional properties', () => {
     interface ObjType {
       a?: {
         b: {
@@ -62,6 +69,12 @@ describe('setByPath', () => {
     }
     const obj: ObjType = {};
     setByPath(obj, 'a.b.c', 'test');
-    expect(obj).toEqual({});
+    expect(obj).toEqual({
+      a: {
+        b: {
+          c: 'test',
+        },
+      },
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,50 +12,50 @@ export type PathConcat<TKey extends string | number, TValue> = TValue extends Pr
 
 export type Path<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-    ? {
-        [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
-      }[TupleKeys<T>]
-    : PathConcat<ArrayKey, V>
+  ? {
+    [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
+  }[TupleKeys<T>]
+  : PathConcat<ArrayKey, V>
   : {
-      [K in keyof T]-?: PathConcat<K & string, T[K]>;
-    }[keyof T];
+    [K in keyof T]-?: PathConcat<K & string, T[K]>;
+  }[keyof T];
 
 type ArrayPathConcat<TKey extends string | number, TValue> = TValue extends Primitive
   ? never
   : TValue extends readonly (infer U)[]
   ? U extends Primitive
-    ? never
-    : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
+  ? never
+  : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
   : `${TKey}.${ArrayPath<TValue>}`;
 
 export type ArrayPath<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-    ? {
-        [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
-      }[TupleKeys<T>]
-    : ArrayPathConcat<ArrayKey, V>
+  ? {
+    [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
+  }[TupleKeys<T>]
+  : ArrayPathConcat<ArrayKey, V>
   : {
-      [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
-    }[keyof T];
+    [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
+  }[keyof T];
 
 export type PathValue<T, TPath extends Path<T> | ArrayPath<T>> = T extends any
   ? TPath extends `${infer K}.${infer R}`
-    ? K extends keyof T
-      ? R extends Path<T[K]>
-        ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
-        : never
-      : K extends `${ArrayKey}`
-      ? T extends readonly (infer V)[]
-        ? PathValue<V, R & Path<V>>
-        : never
-      : never
-    : TPath extends keyof T
-    ? T[TPath]
-    : TPath extends `${ArrayKey}`
-    ? T extends readonly (infer V)[]
-      ? V
-      : never
-    : never
+  ? K extends keyof T
+  ? R extends Path<T[K]>
+  ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
+  : never
+  : K extends `${ArrayKey}`
+  ? T extends readonly (infer V)[]
+  ? PathValue<V, R & Path<V>>
+  : never
+  : never
+  : TPath extends keyof T
+  ? T[TPath]
+  : TPath extends `${ArrayKey}`
+  ? T extends readonly (infer V)[]
+  ? V
+  : never
+  : never
   : never;
 
 export function getByPath<T extends Record<string, any>, TPath extends Path<T>>(
@@ -63,4 +63,21 @@ export function getByPath<T extends Record<string, any>, TPath extends Path<T>>(
   path: TPath,
 ): PathValue<T, TPath> {
   return path.split('.').reduce((acc, key) => acc?.[key], obj) as PathValue<T, TPath>;
+}
+
+export function setByPath<T extends Record<string, any>, TPath extends Path<T>>(
+  obj: T,
+  path: TPath,
+  value: PathValue<T, TPath>
+) {
+  const [key, ...route] = (path.split(".") as TPath[]).reverse();
+
+
+  const target = route.length
+    ? getByPath(obj, route.reverse().join(".") as Path<T>)
+    : obj;
+
+  if (target) {
+    target[key!] = value;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,50 +12,50 @@ export type PathConcat<TKey extends string | number, TValue> = TValue extends Pr
 
 export type Path<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-  ? {
-    [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
-  }[TupleKeys<T>]
-  : PathConcat<ArrayKey, V>
+    ? {
+        [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
+      }[TupleKeys<T>]
+    : PathConcat<ArrayKey, V>
   : {
-    [K in keyof T]-?: PathConcat<K & string, T[K]>;
-  }[keyof T];
+      [K in keyof T]-?: PathConcat<K & string, T[K]>;
+    }[keyof T];
 
 type ArrayPathConcat<TKey extends string | number, TValue> = TValue extends Primitive
   ? never
   : TValue extends readonly (infer U)[]
   ? U extends Primitive
-  ? never
-  : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
+    ? never
+    : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
   : `${TKey}.${ArrayPath<TValue>}`;
 
 export type ArrayPath<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-  ? {
-    [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
-  }[TupleKeys<T>]
-  : ArrayPathConcat<ArrayKey, V>
+    ? {
+        [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
+      }[TupleKeys<T>]
+    : ArrayPathConcat<ArrayKey, V>
   : {
-    [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
-  }[keyof T];
+      [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
+    }[keyof T];
 
 export type PathValue<T, TPath extends Path<T> | ArrayPath<T>> = T extends any
   ? TPath extends `${infer K}.${infer R}`
-  ? K extends keyof T
-  ? R extends Path<T[K]>
-  ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
-  : never
-  : K extends `${ArrayKey}`
-  ? T extends readonly (infer V)[]
-  ? PathValue<V, R & Path<V>>
-  : never
-  : never
-  : TPath extends keyof T
-  ? T[TPath]
-  : TPath extends `${ArrayKey}`
-  ? T extends readonly (infer V)[]
-  ? V
-  : never
-  : never
+    ? K extends keyof T
+      ? R extends Path<T[K]>
+        ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
+        : never
+      : K extends `${ArrayKey}`
+      ? T extends readonly (infer V)[]
+        ? PathValue<V, R & Path<V>>
+        : never
+      : never
+    : TPath extends keyof T
+    ? T[TPath]
+    : TPath extends `${ArrayKey}`
+    ? T extends readonly (infer V)[]
+      ? V
+      : never
+    : never
   : never;
 
 export function getByPath<T extends Record<string, any>, TPath extends Path<T>>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,50 +12,50 @@ export type PathConcat<TKey extends string | number, TValue> = TValue extends Pr
 
 export type Path<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-    ? {
-        [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
-      }[TupleKeys<T>]
-    : PathConcat<ArrayKey, V>
+  ? {
+    [K in TupleKeys<T>]-?: PathConcat<K & string, T[K]>;
+  }[TupleKeys<T>]
+  : PathConcat<ArrayKey, V>
   : {
-      [K in keyof T]-?: PathConcat<K & string, T[K]>;
-    }[keyof T];
+    [K in keyof T]-?: PathConcat<K & string, T[K]>;
+  }[keyof T];
 
 type ArrayPathConcat<TKey extends string | number, TValue> = TValue extends Primitive
   ? never
   : TValue extends readonly (infer U)[]
   ? U extends Primitive
-    ? never
-    : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
+  ? never
+  : `${TKey}` | `${TKey}.${ArrayPath<TValue>}`
   : `${TKey}.${ArrayPath<TValue>}`;
 
 export type ArrayPath<T> = T extends readonly (infer V)[]
   ? IsTuple<T> extends true
-    ? {
-        [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
-      }[TupleKeys<T>]
-    : ArrayPathConcat<ArrayKey, V>
+  ? {
+    [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K]>;
+  }[TupleKeys<T>]
+  : ArrayPathConcat<ArrayKey, V>
   : {
-      [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
-    }[keyof T];
+    [K in keyof T]-?: ArrayPathConcat<K & string, T[K]>;
+  }[keyof T];
 
 export type PathValue<T, TPath extends Path<T> | ArrayPath<T>> = T extends any
   ? TPath extends `${infer K}.${infer R}`
-    ? K extends keyof T
-      ? R extends Path<T[K]>
-        ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
-        : never
-      : K extends `${ArrayKey}`
-      ? T extends readonly (infer V)[]
-        ? PathValue<V, R & Path<V>>
-        : never
-      : never
-    : TPath extends keyof T
-    ? T[TPath]
-    : TPath extends `${ArrayKey}`
-    ? T extends readonly (infer V)[]
-      ? V
-      : never
-    : never
+  ? K extends keyof T
+  ? R extends Path<T[K]>
+  ? undefined extends T[K] ? PathValue<T[K], R> | undefined : PathValue<T[K], R>
+  : never
+  : K extends `${ArrayKey}`
+  ? T extends readonly (infer V)[]
+  ? PathValue<V, R & Path<V>>
+  : never
+  : never
+  : TPath extends keyof T
+  ? T[TPath]
+  : TPath extends `${ArrayKey}`
+  ? T extends readonly (infer V)[]
+  ? V
+  : never
+  : never
   : never;
 
 export function getByPath<T extends Record<string, any>, TPath extends Path<T>>(
@@ -70,14 +70,21 @@ export function setByPath<T extends Record<string, any>, TPath extends Path<T>>(
   path: TPath,
   value: PathValue<T, TPath>
 ) {
-  const [key, ...route] = (path.split(".") as TPath[]).reverse();
+  const segments = path.split('.') as TPath[];
+  const lastKey = segments.pop();
 
+  let target: T = obj;
 
-  const target = route.length
-    ? getByPath(obj, route.reverse().join(".") as Path<T>)
-    : obj;
-
-  if (target) {
-    target[key!] = value;
+  for (const key of segments) {
+    if (!(key in target)) {
+      target[key] = {} as PathValue<T, TPath>;
+    }
+    target = target[key];
   }
+
+  if (lastKey) {
+    target[lastKey] = value;
+  }
+
+  return obj;
 }


### PR DESCRIPTION
So, here is a first draft. There are a few things which are probably up for debate and with which I might need your assistance.

It can replace existing values without issue, and the path and value are both type checked correctly.

However, if you wanted to set a property which does not exist, the `path` parameter will error.

Similarly, if you attempt to set a value within an optional object, this currently fails silently.

Please let me know what you think!

Closes #7