### PR TITLE
Add missing type export declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.esm.js"
+    "default": "./dist/index.esm.js",
+    "types": "./dist/index.d.ts"
   },
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
This will allow people to use this package together with the new moduleResolution: "bundler" option enabled, which was added in TypeScript 5.0.

Otherwise type declarations are entirely missing.