### PR TITLE
Change order making `default` export last.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.esm.js",
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.esm.js"
   },
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
I cannot install this package because I get this error:  `Module not found: Error: Default condition should be last one`

Looking into it further, it looks like there's just some need for `default` to be the last entry in the `exports` object in `package.json`

See: https://nodejs.org/api/packages.html#conditional-exports   (`"default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.`)

This PR was tested with my use-case and fixes the install problem.  Alas, this feels weird. An ordered object? A sudden breakage? Probably because I updated Node recently.

Thank you!