### PR TITLE
Added relative path get and set

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ yarn add dot-path-value
 ## Usage
 
 ```ts
-import { getByPath, setByPath } from 'dot-path-value';
+import { getByPath, setByPath, getByRelativePath, setByRelativePath } from 'dot-path-value';
 
 const obj = {
   a: {
@@ -48,7 +48,7 @@ const obj = {
     d: [
       {
         e: 'world',
-      }
+      },
     ],
   },
 };
@@ -63,12 +63,20 @@ getByPath(obj, 'a.d.0'); // outputs '{ e: 'world' }' with type `{ e: string }`
 // also you can pass array as first argument
 getByPath([{ a: 1 }], '0.a'); // outputs '1' with type `number`
 
+// get a property from a relative path to another path
+getByRelativePath(obj, 'a.d.0', '../../b'); // outputs 'hello'
+
+// also you can use a mix of slash and dot notation
+getByRelativePath(obj, 'a.b', '../d.0/e'); // outputs 'world'
+
 // typescript errors
 getByPath(obj, 'a.b.c'); // `c` property does not exist
 
-
 // set a property through an object
-setByPath(obj, 'a.b', 'hello there');
+setByPath(obj, 'a.b', 'hello there'); // obj.a.b === 'hello there'
+
+// set a property from a relative path to another path
+setByRelativePath(obj, 'a.d.0.e', '../../../b', 'general kenobi'); // obj.a.b === 'general kenobi'
 ```
 
 ## Types

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { getByPath, setByPath } from './index';
+import { getByPath, getByRelativePath, setByPath, setByRelativePath } from './index';
 
 describe('getByPath', () => {
   const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
@@ -25,6 +25,37 @@ describe('getByPath', () => {
     }
     const obj: ObjType = {};
     expect(getByPath(obj, 'a.b.c')).toBe(undefined);
+  });
+});
+
+describe('getByRelativePath', () => {
+  test('should return the value at the specified relative path', () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+    expect(getByRelativePath(obj, 'a.b.c', '..')).toBe(obj.a.b);
+    expect(getByRelativePath(obj, 'd.1.e', '')).toBe(obj.d[1]?.e);
+    expect(getByRelativePath(obj, 'd.0', '../0')).toBe(obj.d[0]);
+    expect(getByRelativePath(obj, 'd.1.e', '../..')).toBe(obj.d);
+    expect(getByRelativePath(obj, 'd.1.e', '../../../..')).toBe(obj);
+  });
+
+  test('should work with arrays', () => {
+    const arr = [{ a: 1 }, { b: { c: 2 } }];
+    expect(getByRelativePath(arr, '0', '..')).toBe(arr);
+    expect(getByRelativePath(arr, '2.a', '..')).toBe(arr[2]);
+    expect(getByRelativePath(arr, '2.a', '../..')).toBe(arr);
+  });
+
+  test('should work with a mix of back references and forward paths', () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+    expect(getByRelativePath(obj, 'd.1.e', '../../0.e')).toBe(obj.d[0]?.e);
+    expect(getByRelativePath(obj, 'd.1.e', '../../../d.0.e')).toBe(obj.d[0]?.e);
+  });
+
+  test('should work with a mix of back references and forward paths using only slashes', () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+    // expect(getByRelativePath(obj, 'd.1.e', '../../0/e')).toBe(obj.d[0]?.e);
+    // expect(getByRelativePath(obj, 'd.1.e', '../../../d/0/e')).toBe(obj.d[0]?.e);
+    expect(getByRelativePath(obj, 'd.1.e', '..\\..\\..\\d\\0\\e')).toBe(obj.d[0]?.e);
   });
 });
 
@@ -74,5 +105,35 @@ describe('setByPath', () => {
         },
       },
     });
+  });
+});
+
+describe('setByRelativePath', () => {
+  test('should set the value at the specified relative path', () => {
+    const obj = { a: { b: { c: 1 } }, d: [{ e: 2 }, { e: 3 }] };
+
+    setByRelativePath(obj, 'a.b.c', '', 2);
+    expect(obj.a.b.c).toBe(2);
+
+    setByRelativePath(obj, 'a.b.c', '..', 2);
+    expect(obj.a.b).toBe(2);
+
+    setByRelativePath(obj, 'a.b.c', '../../../d', 2);
+    expect(obj.d).toBe(2);
+
+    const objBeforeFailedSet = structuredClone(obj);
+
+    setByRelativePath(obj, 'a.b.c', '../../../..', 2);
+    expect(obj).toEqual(objBeforeFailedSet);
+  });
+
+  test('should work with arrays', () => {
+    const arr = [{ a: 1 }, { b: { c: 2 } }];
+
+    setByRelativePath(arr, '1.b', '..', 3);
+    expect(arr).toEqual([{ a: 1 }, 3]);
+
+    setByRelativePath(arr, '1.b', '../../0/a', 3);
+    expect(arr).toEqual([{ a: 3 }, 3]);
   });
 });


### PR DESCRIPTION
I'm coming from a specific use case on my side where I have an initial path and want to manipulate the object with a relative path from the initial.
After getting it working I thought it could be useful to include it on your package.

## Explanation

We are going to start with this object:

```ts
const obj = {
  a: {
    b: 'hello',
    d: [
      {
        e: 'world',
      },
    ],
  },
};
```

This PR is composed into two parts:

### getByRelativePath(obj, path, relativePath)

1. I know the initial path `'a.d.0'`
2. I want to **get** the value that's relative to the initial path `../../b`
3. I call `getByRelativePath(obj, 'a.d.0', '../../b')`
4. It should be able to step back twice (`'../../'` takes the context to `a`) and step forward once (`'b'` takes the context to `a.b`)
5. I'm expected to get `'hello'`

### setByRelativePath(obj, path, relativePath, value)

1. I know the initial path `'a.d.0'`
2. I want to **set** the value that's relative to the initial path `../../b`
3. I call `setByRelativePath(obj, 'a.d.0', '../../b', 'good morning')`
4. It should be able to step back twice (`'../../'` takes the context to `a`) and step forward once (`'b'` takes the context to `a.b`)
5. I'm expected `obj.a.b === 'good morning'`


**Note**: Take into account that I'm not well knowledgeable in typescript and learned a good deal with your code. Still I know there is some work to be done on this PR related with that.

Can I get some help on that maybe? :)