### PR TITLE
fix(types): include numeric object keys in Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,29 @@ types such as `interface Node { child: Node }` compiling instead of failing with
 "circularly references itself". Every type takes the depth as an optional second parameter if
 you need something else: `Path<T, 4>`.
 
+Numeric object keys are included, so `Path<{ days: { 1: boolean } }>` is
+`'days' | 'days.1'`.
+
+### Using the types in your own generic functions
+
+Take the path as its own type parameter. Otherwise `TPath` stays widened to the full union of
+paths and the return type widens to the union of every value type along with it:
+
+```ts
+// ❌ `value` is the union of every value type in `T`
+function pluck<T extends Record<string, any>>(obj: T, path: Path<T>) {
+  return getByPath(obj, path);
+}
+
+// ✅ `value` is the type at the path that was actually passed
+function pluck<T extends Record<string, any>, TPath extends Path<T>>(obj: T, path: TPath) {
+  return getByPath(obj, path);
+}
+```
+
+This is how `getByPath` and `setByPath` are declared, and it is a TypeScript inference rule
+rather than something the library can work around.
+
 ### Types usage
 
 ```ts

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -44,6 +44,12 @@ describe('Path', () => {
   test('unwraps optional properties', () => {
     expectTypeOf<'optional.deep'>().toExtend<Path<Obj>>();
   });
+
+  test('picks up numeric object keys', () => {
+    expectTypeOf<Path<{ days: { 1: boolean; '2': boolean; 3: boolean } }>>().toEqualTypeOf<
+      'days' | 'days.1' | 'days.2' | 'days.3'
+    >();
+  });
 });
 
 describe('ArrayPath', () => {
@@ -64,6 +70,16 @@ describe('PathValue', () => {
 
   test('adds undefined for optional segments', () => {
     expectTypeOf<PathValue<Obj, 'optional.deep'>>().toEqualTypeOf<number | undefined>();
+  });
+
+  test('resolves numeric object keys', () => {
+    interface Days {
+      days: { 1: boolean; '2': number; 3: string };
+    }
+
+    expectTypeOf<PathValue<Days, 'days.1'>>().toEqualTypeOf<boolean>();
+    expectTypeOf<PathValue<Days, 'days.2'>>().toEqualTypeOf<number>();
+    expectTypeOf<PathValue<Days, 'days.3'>>().toEqualTypeOf<string>();
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,13 @@ describe('getByPath', () => {
     expect(getByPath(arr, '2.a')).toBe(3);
   });
 
+  test('should work with numeric object keys', () => {
+    const days = { days: { 1: true, '2': false, 3: true } };
+    expect(getByPath(days, 'days.1')).toBe(true);
+    expect(getByPath(days, 'days.2')).toBe(false);
+    expect(getByPath(days, 'days.3')).toBe(true);
+  });
+
   test('should work with optional keys', () => {
     interface ObjType {
       a?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,13 @@ export type Terminal =
 
 type ArrayKey = number;
 
+/**
+ * Keys a path segment can be built from. `number` is required because object
+ * literals may declare numeric keys (`{ 1: true }`), and `keyof` reports those
+ * as number literals rather than strings.
+ */
+type PathKey = string | number;
+
 type IsTuple<T extends readonly any[]> = number extends T['length'] ? false : true;
 
 type TupleKeys<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
@@ -37,11 +44,11 @@ export type Path<T, TDepth extends number = MaxPathDepth> = [TDepth] extends [ne
   : T extends readonly (infer V)[]
     ? IsTuple<T> extends true
       ? {
-          [K in TupleKeys<T>]-?: PathConcat<K & string, T[K], Prev[TDepth]>;
+          [K in TupleKeys<T>]-?: PathConcat<K & PathKey, T[K], Prev[TDepth]>;
         }[TupleKeys<T>]
       : PathConcat<ArrayKey, V, Prev[TDepth]>
     : {
-        [K in keyof T]-?: PathConcat<K & string, T[K], Prev[TDepth]>;
+        [K in keyof T]-?: PathConcat<K & PathKey, T[K], Prev[TDepth]>;
       }[keyof T];
 
 type ArrayPathConcat<
@@ -61,32 +68,49 @@ export type ArrayPath<T, TDepth extends number = MaxPathDepth> = [TDepth] extend
   : T extends readonly (infer V)[]
     ? IsTuple<T> extends true
       ? {
-          [K in TupleKeys<T>]-?: ArrayPathConcat<K & string, T[K], Prev[TDepth]>;
+          [K in TupleKeys<T>]-?: ArrayPathConcat<K & PathKey, T[K], Prev[TDepth]>;
         }[TupleKeys<T>]
       : ArrayPathConcat<ArrayKey, V, Prev[TDepth]>
     : {
-        [K in keyof T]-?: ArrayPathConcat<K & string, T[K], Prev[TDepth]>;
+        [K in keyof T]-?: ArrayPathConcat<K & PathKey, T[K], Prev[TDepth]>;
       }[keyof T];
+
+/**
+ * Maps a path segment back to the key it came from. A segment is always a
+ * string, so a numeric key such as `{ 1: true }` has to be matched through its
+ * numeric literal form.
+ */
+type ResolveKey<T, TKey> = TKey extends keyof T
+  ? TKey
+  : TKey extends `${infer N extends number}`
+    ? N extends keyof T
+      ? N
+      : never
+    : never;
 
 export type PathValue<T, TPath extends Path<T> | ArrayPath<T>> = T extends any
   ? TPath extends `${infer K}.${infer R}`
-    ? K extends keyof T
-      ? R extends Path<T[K]>
-        ? undefined extends T[K]
-          ? PathValue<T[K], R> | undefined
-          : PathValue<T[K], R>
-        : never
-      : K extends `${ArrayKey}`
+    ? [ResolveKey<T, K>] extends [never]
+      ? K extends `${ArrayKey}`
         ? T extends readonly (infer V)[]
           ? PathValue<V, R & Path<V>>
           : never
         : never
-    : TPath extends keyof T
-      ? T[TPath]
-      : TPath extends `${ArrayKey}`
+      : ResolveKey<T, K> extends infer TResolved extends keyof T
+        ? R extends Path<T[TResolved]>
+          ? undefined extends T[TResolved]
+            ? PathValue<T[TResolved], R> | undefined
+            : PathValue<T[TResolved], R>
+          : never
+        : never
+    : [ResolveKey<T, TPath>] extends [never]
+      ? TPath extends `${ArrayKey}`
         ? T extends readonly (infer V)[]
           ? V
           : never
+        : never
+      : ResolveKey<T, TPath> extends infer TResolved extends keyof T
+        ? T[TResolved]
         : never
   : never;
 


### PR DESCRIPTION
Closes #15.

## Problem

`keyof { 1: true, "2": false, 3: true }` yields `1 | "2" | 3` — the numeric keys stay number literals. The mapped types intersected each key with `string`, which collapsed those to `never`, so:

```ts
type PathObj = Path<{ days: { 1: true; "2": false; 3: true } }>;
//   ^? "days" | "days.2"
```

## Fix

- Intersect map keys with `string | number` (`PathKey`) in `Path` and `ArrayPath`, so numeric keys survive the `${K}` template.
- Add `ResolveKey<T, TKey>` in `PathValue`: a path segment is always a string, so a segment like `"1"` has to be matched back to the numeric key `1`. Without this the type was fixed but `PathValue<Days, "days.1">` still resolved to `never`.

```ts
type PathObj = Path<{ days: { 1: true; "2": false; 3: true } }>;
//   ^? "days" | "days.1" | "days.2" | "days.3"
```

## Also

Documents the `TPath extends Path<T>` pattern for generic wrapper functions in the README (#10) — declaring the parameter as a bare `Path<T>` widens the return type to every value type in the object.

## Verification

`pnpm test` — 31 passed (up from 28), no type errors. `pnpm lint` and `pnpm format:check` clean. New coverage: `Path` enumerates numeric keys, `PathValue` resolves each of them, and a runtime `getByPath` test over numeric keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)