### PR TITLE
build: push only reachable tags after `npm version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:check": "oxfmt --check",
     "check:exports": "publint && attw --pack .",
     "prepublishOnly": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build && pnpm run check:exports",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push --follow-tags"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
One-line change to the `postversion` hook.

```diff
-"postversion": "git push && git push --tags"
+"postversion": "git push --follow-tags"
```

## Why

`git push --tags` pushes **every** local tag, reachable or not. Combined with `publish.yaml` triggering on `tags: ['v*']`, a leftover tag from an abandoned version bump gets published on the next release — staging a release from whatever commit that tag happens to point at.

This is not hypothetical: the repo had a local `v1.0.0` on `ce22e1e`, a commit that was never merged, left behind by an `npm version major` whose `git push` failed with a non-fast-forward (which is the only reason `&&` stopped the tag push and the tag never escaped). That tag has since been deleted.

`--follow-tags` pushes only annotated tags reachable from the commit being pushed — exactly the tag `npm version` just created.

## Verification

Dry-run with two throwaway annotated tags, one on an ancestor of HEAD and one on the orphaned `ce22e1e`:

| Tag | Commit | `git push --tags` | `git push --follow-tags` |
| --- | --- | --- | --- |
| `v9.9.8` | ancestor of HEAD | pushed | pushed |
| `v9.9.9` | `ce22e1e`, not an ancestor | **pushed** | skipped |

So the new hook would not have leaked `v1.0.0`.

## Limit worth knowing

`--follow-tags` still pushes a stale annotated tag if it sits on a commit that *is* reachable from the one being pushed. It narrows the blast radius rather than eliminating it; the real guard against a bad release remains the stage-only trusted publisher and its 2FA approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)